### PR TITLE
Non pk session

### DIFF
--- a/lib/Dancer2/Session/DBIC.pm
+++ b/lib/Dancer2/Session/DBIC.pm
@@ -83,6 +83,9 @@ has resultset => (
 
 Column for session id, defaults to C<sessions_id>.
 
+If this column is not the primary key of the table, it should have
+a unique constraint added to it.  See L<DBIx::Class::ResultSource/add_unique_constraint>.
+
 =cut
 
 has id_column => (

--- a/lib/Dancer2/Session/DBIC.pm
+++ b/lib/Dancer2/Session/DBIC.pm
@@ -179,7 +179,7 @@ sub _retrieve {
     my ($self, $session_id) = @_;
     my $session_object;
 
-    $session_object = $self->_rset->find($session_id);
+    $session_object = $self->_rset->find({ $self->id_column => $session_id });
 
     # Bail early if we know we have no session data at all
     if (!defined $session_object) {

--- a/lib/Dancer2/Session/DBIC.pm
+++ b/lib/Dancer2/Session/DBIC.pm
@@ -223,7 +223,7 @@ sub _destroy {
         return;
     }
 
-    $self->_rset->find($id)->delete;
+    $self->_rset->find({ $self->id_column => $id})->delete;
 }
 
 # Creates and connects schema

--- a/lib/Dancer2/Session/DBIC.pm
+++ b/lib/Dancer2/Session/DBIC.pm
@@ -187,7 +187,8 @@ sub _retrieve {
         return;
     }
 
-    my $session_data = $session_object->session_data;
+    my $data_column  = $self->data_column;
+    my $session_data = $session_object->$data_column;
 
     # No way to check that it's valid JSON other than trying to deserialize it
     my $session = try {

--- a/t/lib/Test/SchemaNonPK.pm
+++ b/t/lib/Test/SchemaNonPK.pm
@@ -1,0 +1,10 @@
+package Test::SchemaNonPK;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Schema';
+
+__PACKAGE__->load_namespaces;
+
+1;

--- a/t/lib/Test/SchemaNonPK/Result/Session.pm
+++ b/t/lib/Test/SchemaNonPK/Result/Session.pm
@@ -1,0 +1,30 @@
+package Test::SchemaNonPK::Result::Session;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->load_components(qw(TimeStamp));
+
+__PACKAGE__->table("sessions");
+
+__PACKAGE__->add_columns(
+  "pk_id",
+  { data_type => "integer", is_nullable => 0 },
+  "sessions_id",
+  { data_type => "varchar", is_nullable => 0, size => 255 },
+  "session_data",
+  { data_type => "text", is_nullable => 0 },
+  "created",
+  { data_type => "datetime", set_on_create => 1, is_nullable => 0 },
+  "last_modified",
+  { data_type => "datetime", set_on_create => 1, is_nullable => 0 },
+);
+
+__PACKAGE__->set_primary_key("pk_id");
+__PACKAGE__->add_unique_constraint(
+    'unique_sessions_id' => [ qw/ sessions_id / ],
+);
+
+1;

--- a/t/schema.t
+++ b/t/schema.t
@@ -14,6 +14,7 @@ use lib File::Spec->catdir( 't', 'lib' );
 use DBICx::TestDatabase;
 
 test_session_schema('Test::Schema');
+test_session_schema('Test::SchemaNonPK');
 test_session_schema('Test::Custom', {resultset => 'Custom',
                                      id_column => 'customs_id',
                                      data_column => 'custom_data'});


### PR DESCRIPTION
* Fix a bug in _retrieve, using the configured session data column name instead of ->session_data always 8a90fc5
* session_id column works now if it is not the primary key; column at least needs a unique constraint 9d353c8
* tests and docs (f57ada7, 76f7d95)