### PR TITLE
Remove handles hash

### DIFF
--- a/t/schema.t
+++ b/t/schema.t
@@ -54,7 +54,7 @@ foreach my $serializer ( 'JSON', 'Sereal', 'YAML' ) {
 }
 
 sub test_session_schema {
-    %Dancer2::Session::DBIC::dbic_handles = ();
+    $Dancer2::Session::DBIC::_schema = undef;
     my ($schema_class, $schema_options) = @_;
 
     note "Testing $schema_class";


### PR DESCRIPTION
The pid_tid trick is gone but the Interchange6 plugin is still looking for a "default" schema (GH #13)